### PR TITLE
Upgrade asdf action versions to v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Install asdf
-      uses: asdf-vm/actions/setup@v3
+      uses: asdf-vm/actions/setup@v4
     - name: Cache asdf
       id: cache
       uses: actions/cache@v4
@@ -21,7 +21,7 @@ runs:
         key: asdf-${{ hashFiles('**/.tool-versions') }}
     - name: Install asdf tools
       if: steps.cache.outputs.cache-hit != 'true'
-      uses: asdf-vm/actions/install@v3
+      uses: asdf-vm/actions/install@v4
     - name: Check pnpm
       id: pnpm
       shell: bash


### PR DESCRIPTION
Hi,

I believe a v2 of this plugin would make sense, because of the changes in asdf 0.16.0 and above. (e.g. `plugin-add` is removed, you have `plugin add` instead)

This PR updates the dependencies to v4, which support asdf 0.16.0, and it works well in my projects. Since this is already published to the marketplace, I believe others would benefit from an updated version.

Thank you for this action, it saves a lot of headaches in my projects.